### PR TITLE
Feature Request: Add intuitive CI for user-defined tests on commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI - Run Tests
+
+on:
+  push:
+    branches:
+      - main
+      - 'feature/*'
+  pull_request:
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm install
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run backend tests
+        working-directory: backend
+        run: pytest
+
+      - name: Run frontend tests
+        working-directory: frontend
+        run: ./tests/test_frontend.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Contributor Guide
+
+This repository contains a small FastAPI backend and a Vite + React frontend. Keep code clear and concise and prefer the packages already listed in `backend/requirements.txt` and `frontend/package.json`.
+
+## Running the project
+See **README.md** for full instructions. In short:
+
+```bash
+pip install -r backend/requirements.txt
+npm install --prefix frontend
+```
+
+The backend tests are run with `pytest` from the project root and the frontend test script is `./frontend/tests/test_frontend.sh`.
+
+## Continuous Integration
+The workflow in `.github/workflows/ci.yml` mirrors these commands. Pushes and pull requests automatically install the dependencies and execute the tests.
+
+Before submitting a PR:
+1. Run the same commands locally and ensure they pass.
+2. Keep commit messages and PR descriptions short and informative.
+
+

--- a/README.md
+++ b/README.md
@@ -61,3 +61,18 @@ cd frontend
 
 The backend tests verify the `/api/hello` route. The frontend test starts the Vite dev server and checks that the page contains "Hello World".
 
+
+## Continuous Integration
+
+This repository uses GitHub Actions to run tests automatically on every push and pull request. The workflow installs dependencies and executes the same test commands described above.
+
+To run the tests locally:
+
+```bash
+pip install -r backend/requirements.txt
+npm install --prefix frontend
+cd backend && pytest
+cd frontend && ./tests/test_frontend.sh
+```
+
+If any step fails, the workflow marks the commit as failed on GitHub.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 httpx
+pytest


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that installs dependencies and runs tests
- document how CI works in the README

## Testing
- `pytest -q`
- `npm install`
- `./tests/test_frontend.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840dfd4d4688321ab01245ec27390ff