### PR TITLE
Implement basic RAG indexing demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
 
       - name: Run frontend tests
         working-directory: frontend
-        run: npm test
+        run: npm test -- --watch=false

--- a/README.md
+++ b/README.md
@@ -88,3 +88,30 @@ cd frontend && npm test
 ```
 
 If any step fails, the workflow marks the commit as failed on GitHub.
+
+## RAG Indexing Feature
+
+This project includes a simple Retrieval-Augmented Generation indexing demo. To
+index your own notes:
+
+```
+pip install -r backend/requirements.txt
+npm install --prefix frontend
+
+# run backend
+uvicorn main:app --reload --port 8000 --app-dir backend
+
+# run frontend
+npm --prefix frontend run dev
+```
+
+Navigate to the "Index Notes" form in the frontend, paste some text, and click
+"Index Notes". The backend will split the text into paragraphs and sentences,
+generate dummy embeddings, and store them in in-memory FAISS indexes.
+
+Run tests with:
+
+```
+cd backend && pytest
+cd ../frontend && npm test -- --watch=false
+```

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
 
-from rag_indexing import index_text_block, get_index_counts
+from rag_indexing import index_text_block, get_index_counts, get_index_sample, clear_indexes
 
 app = FastAPI()
 
@@ -19,6 +19,15 @@ async def index_notes(payload: TextPayload):
     try:
         index_text_block(payload.text)
         counts = get_index_counts()
-        return {"status": "success", "counts": counts}
+        sample = get_index_sample()
+        return {"status": "success", "counts": counts, "sample": sample}
+    except Exception as e:
+        return {"status": "error", "message": str(e)}
+
+@app.post("/api/clear")
+async def clear_index():
+    try:
+        clear_indexes()
+        return {"status": "success"}
     except Exception as e:
         return {"status": "error", "message": str(e)}

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,24 @@
 from fastapi import FastAPI
+from pydantic import BaseModel
+
+from rag_indexing import index_text_block, get_index_counts
 
 app = FastAPI()
 
 @app.get("/api/hello")
 async def read_hello():
     return {"message": "Hello from FastAPI!"}
+
+
+class TextPayload(BaseModel):
+    text: str
+
+
+@app.post("/api/index")
+async def index_notes(payload: TextPayload):
+    try:
+        index_text_block(payload.text)
+        counts = get_index_counts()
+        return {"status": "success", "counts": counts}
+    except Exception as e:
+        return {"status": "error", "message": str(e)}

--- a/backend/rag_indexing.py
+++ b/backend/rag_indexing.py
@@ -92,6 +92,13 @@ def get_index_counts() -> Dict[str, int]:
         "sentences": sentence_index.ntotal if sentence_index else 0,
     }
 
+def get_index_sample() -> Dict[str, List[str]]:
+    return {
+        "documents": _document_texts[:5],
+        "paragraphs": _paragraph_texts[:5],
+        "sentences": _sentence_texts[:5],
+    }
+
 
 def clear_indexes() -> None:
     global document_index, paragraph_index, sentence_index

--- a/backend/rag_indexing.py
+++ b/backend/rag_indexing.py
@@ -1,0 +1,103 @@
+import logging
+import re
+from typing import List, Dict
+import numpy as np
+import faiss
+
+logger = logging.getLogger(__name__)
+
+EMBED_DIM = 384
+
+# Initialize in-memory FAISS indexes
+try:
+    document_index = faiss.IndexFlatL2(EMBED_DIM)
+    paragraph_index = faiss.IndexFlatL2(EMBED_DIM)
+    sentence_index = faiss.IndexFlatL2(EMBED_DIM)
+    logger.info("[PHASE 2] DB Instances initialized")
+except Exception as e:
+    logger.error("[PHASE 2 ERROR] Failed to init indexes: %s", e)
+    document_index = paragraph_index = sentence_index = None
+
+# Store metadata for verification/tests
+_document_texts: List[str] = []
+_paragraph_texts: List[str] = []
+_sentence_texts: List[str] = []
+
+def split_into_paragraphs(text: str) -> List[str]:
+    paragraphs = [p.strip() for p in re.split(r"\n\n+", text.strip()) if p.strip()]
+    result = []
+    for para in paragraphs:
+        words = para.split()
+        while len(words) > 500:
+            result.append(" ".join(words[:500]))
+            words = words[500:]
+        if words:
+            result.append(" ".join(words))
+    return result
+
+
+def split_into_sentences(text: str) -> List[str]:
+    raw_sentences = re.split(r"(?<=[.!?])\s+", text.strip())
+    result = []
+    for sent in raw_sentences:
+        words = sent.split()
+        while len(words) > 30:
+            result.append(" ".join(words[:30]))
+            words = words[30:]
+        if words:
+            result.append(" ".join(words))
+    return [s for s in result if s]
+
+
+def embed_text_chunks(chunks: List[str]) -> List[np.ndarray]:
+    vectors = []
+    for chunk in chunks:
+        # Dummy embedding: hash-based seed for determinism in tests
+        seed = abs(hash(chunk)) % (2 ** 32)
+        rng = np.random.default_rng(seed)
+        vectors.append(rng.random(EMBED_DIM, dtype=np.float32))
+    return vectors
+
+
+def index_text_block(text: str) -> None:
+    document_chunks = [text]
+    paragraph_chunks = split_into_paragraphs(text)
+    sentence_chunks = split_into_sentences(text)
+
+    logger.info("[PHASE 2] Splitting input: %d document, %d paragraphs, %d sentences", len(document_chunks), len(paragraph_chunks), len(sentence_chunks))
+
+    doc_vectors = embed_text_chunks(document_chunks)
+    para_vectors = embed_text_chunks(paragraph_chunks)
+    sent_vectors = embed_text_chunks(sentence_chunks)
+
+    for vec, chunk in zip(doc_vectors, document_chunks):
+        document_index.add(np.array([vec]))
+        _document_texts.append(chunk)
+
+    for vec, chunk in zip(para_vectors, paragraph_chunks):
+        paragraph_index.add(np.array([vec]))
+        _paragraph_texts.append(chunk)
+
+    for vec, chunk in zip(sent_vectors, sentence_chunks):
+        sentence_index.add(np.array([vec]))
+        _sentence_texts.append(chunk)
+
+    logger.info("[PHASE 2] Added vectors to indexes")
+
+
+def get_index_counts() -> Dict[str, int]:
+    return {
+        "documents": document_index.ntotal if document_index else 0,
+        "paragraphs": paragraph_index.ntotal if paragraph_index else 0,
+        "sentences": sentence_index.ntotal if sentence_index else 0,
+    }
+
+
+def clear_indexes() -> None:
+    global document_index, paragraph_index, sentence_index
+    document_index.reset()
+    paragraph_index.reset()
+    sentence_index.reset()
+    _document_texts.clear()
+    _paragraph_texts.clear()
+    _sentence_texts.clear()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,6 @@ fastapi
 uvicorn
 httpx
 pytest
+llama-index
+faiss-cpu
+numpy

--- a/backend/tests/test_rag_indexing.py
+++ b/backend/tests/test_rag_indexing.py
@@ -1,0 +1,41 @@
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+from fastapi.testclient import TestClient
+from main import app
+from rag_indexing import (
+    split_into_paragraphs,
+    split_into_sentences,
+    clear_indexes,
+    get_index_counts,
+)
+
+client = TestClient(app)
+
+
+def test_split_paragraphs_long_text():
+    text = "word " * 600
+    paras = split_into_paragraphs(text)
+    assert all(len(p.split()) <= 500 for p in paras)
+    assert sum(len(p.split()) for p in paras) == 600
+
+
+def test_split_sentences_long_sentence():
+    text = " ".join(["word"] * 90) + "."
+    sents = split_into_sentences(text)
+    assert all(len(s.split()) <= 30 for s in sents)
+    assert sum(len(s.split()) for s in sents) == 90
+
+
+def test_index_endpoint():
+    clear_indexes()
+    resp = client.post("/api/index", json={"text": "This is a test. Another one!"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "success"
+    counts = data["counts"]
+    assert counts["documents"] == 1
+    assert counts["paragraphs"] >= 1
+    assert counts["sentences"] == 2

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import IndexNotesForm from './IndexNotesForm'
 
 function App() {
   const [message, setMessage] = useState('')
@@ -14,6 +15,7 @@ function App() {
     <>
       <h1>Hello World</h1>
       {message && <p>{message}</p>}
+      <IndexNotesForm />
     </>
   )
 }

--- a/frontend/src/IndexNotesForm.jsx
+++ b/frontend/src/IndexNotesForm.jsx
@@ -1,40 +1,72 @@
-import { useState } from 'react'
+import { useState } from "react";
+import ChunkedDisplay from "./components/ChunkedDisplay";
 
 function IndexNotesForm() {
-  const [text, setText] = useState('')
-  const [status, setStatus] = useState('')
+  const [debug, setDebug] = useState(false);
+  const [text, setText] = useState("");
+  const [sample, setSample] = useState("");
+  const [status, setStatus] = useState("");
 
   const submit = async () => {
     if (!text.trim()) {
-      setStatus('Please enter text')
-      return
+      setStatus("Please enter text");
+      return;
     }
-    setStatus('Indexing in progress...')
+    setStatus("Indexing in progress...");
     try {
-      const res = await fetch('/api/index', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text })
-      })
-      const data = await res.json()
-      if (data.status === 'success') {
-        setStatus('Indexing complete!')
+      const res = await fetch("/api/index", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text }),
+      });
+      const data = await res.json();
+      if (data.status === "success") {
+        setStatus("Indexing complete!");
+        setSample(data.sample);
       } else {
-        setStatus('Indexing failed: ' + data.message)
+        setStatus("Indexing failed: " + data.message);
       }
     } catch (err) {
-      setStatus('Indexing failed: ' + err.message)
+      setStatus("Indexing failed: " + err.message);
     }
-  }
+  };
+
+  const clearDB = async () => {
+    const res = await fetch("/api/clear", {
+      method: "POST",
+    });
+    const data = await res.json();
+    if (data.status === "success") {
+      setStatus("Database cleared!");
+    } else {
+      setStatus("Database clearing failed: " + data.message);
+    }
+  };
 
   return (
     <div>
       <h2>Index Notes</h2>
-      <textarea value={text} onChange={e => setText(e.target.value)} aria-label="notes-input" />
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        aria-label="notes-input"
+      />
       <button onClick={submit}>Index Notes</button>
+      <button onClick={clearDB}>Clear DB</button>
+      <button onClick={() => setDebug(!debug)}>
+        {debug ? "Hide Debug" : "Show Debug"}
+      </button>
       {status && <p>{status}</p>}
+      {debug && sample && (
+        <div>
+          <h3>Debug</h3>
+          <ChunkedDisplay items={sample.documents} title="Sample documents" />
+          <ChunkedDisplay items={sample.paragraphs} title="Sample paragraphs" />
+          <ChunkedDisplay items={sample.sentences} title="Sample sentences" />
+        </div>
+      )}
     </div>
-  )
+  );
 }
 
-export default IndexNotesForm
+export default IndexNotesForm;

--- a/frontend/src/IndexNotesForm.jsx
+++ b/frontend/src/IndexNotesForm.jsx
@@ -1,0 +1,40 @@
+import { useState } from 'react'
+
+function IndexNotesForm() {
+  const [text, setText] = useState('')
+  const [status, setStatus] = useState('')
+
+  const submit = async () => {
+    if (!text.trim()) {
+      setStatus('Please enter text')
+      return
+    }
+    setStatus('Indexing in progress...')
+    try {
+      const res = await fetch('/api/index', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text })
+      })
+      const data = await res.json()
+      if (data.status === 'success') {
+        setStatus('Indexing complete!')
+      } else {
+        setStatus('Indexing failed: ' + data.message)
+      }
+    } catch (err) {
+      setStatus('Indexing failed: ' + err.message)
+    }
+  }
+
+  return (
+    <div>
+      <h2>Index Notes</h2>
+      <textarea value={text} onChange={e => setText(e.target.value)} aria-label="notes-input" />
+      <button onClick={submit}>Index Notes</button>
+      {status && <p>{status}</p>}
+    </div>
+  )
+}
+
+export default IndexNotesForm

--- a/frontend/src/IndexNotesForm.test.jsx
+++ b/frontend/src/IndexNotesForm.test.jsx
@@ -1,0 +1,21 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import IndexNotesForm from './IndexNotesForm'
+import { describe, it, expect, vi } from 'vitest'
+
+describe('IndexNotesForm', () => {
+  it('submits text to backend', async () => {
+    const fetchMock = vi.spyOn(window, 'fetch').mockResolvedValue({
+      json: async () => ({ status: 'success', counts: { documents: 1, paragraphs: 1, sentences: 1 } })
+    })
+    render(<IndexNotesForm />)
+    const textbox = screen.getByLabelText('notes-input')
+    fireEvent.change(textbox, { target: { value: 'Test note' } })
+    fireEvent.click(screen.getByRole('button', { name: /index notes/i }))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/index')
+    await waitFor(() => {
+      expect(screen.getByText('Indexing complete!')).toBeInTheDocument()
+    })
+    fetchMock.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- add FAISS-based in-memory indexes and text split utilities
- expose `/api/index` endpoint for submitting note text
- add React form to send text to the backend
- create backend and frontend tests for indexing flow
- update CI and docs for the new feature

## Testing
- `pytest -q`
- `npm test -- --watch=false`

------
https://chatgpt.com/codex/tasks/task_e_6840f84717588321adb414afcbd282de